### PR TITLE
use suid-wrapped to fix perms for rstudio

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -26,6 +26,12 @@ ENV RSESSION_PROXY_RSTUDIO_1_4=yes
 
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 
+# Workaround for https://issuetracker.google.com/issues/216190252 
+# Run suid-wrapped command during Notebook startup
+RUN curl --silent -L --fail https://github.com/thiagorb/suid-wrapper/releases/latest/download/suid-wrapper > /tmp/suid-wrapper
+RUN chmod +x /tmp/suid-wrapper && mv /tmp/suid-wrapper /usr/bin/suid-wrapper
+RUN suid-wrapper $(which chmod) +t /var/run/rstudio-server -o /tmp/add_sticky_bit --force
+
 USER $NB_USER
 
 RUN pip install nbgitpuller && \


### PR DESCRIPTION
Rstudio requires the sticky bit permission be set on its working directory, which is getting stripped by Google container filesystem (see issue: https://issuetracker.google.com/issues/216190252) when using image streaming. 

Note: alternate approach would be to use ENV vars and this version of rsession-proxy: https://github.com/jupyterhub/jupyter-rsession-proxy/pull/86 to override rstudio startup with something like `rserver --server-data-dir=/tmp/dir_owned_by_jovyan`